### PR TITLE
Add setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install dependencies for the root project
+echo "Installing root dependencies..."
+npm install
+
+# Install dependencies for the React Native mobile app
+if [ -d mobile ]; then
+  echo "Installing mobile dependencies..."
+  pushd mobile
+  npm install
+  popd
+fi
+
+# Run the category setup script
+echo "Running category setup script..."
+npx -y ts-node server/setup-categories.ts

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# VocabMaster Setup
+
+This repository contains the web server and React Native mobile app for **VocabMaster**.
+
+## Setup Script
+
+A convenience script is provided to install dependencies for both the main project and the mobile application and to initialize default categories in the database.
+
+```bash
+# from the repository root
+chmod +x .codex/setup.sh
+./.codex/setup.sh
+```
+
+The script performs the following steps:
+
+1. Installs root project dependencies using `npm install`.
+2. Installs mobile app dependencies inside the `mobile` directory.
+3. Runs `server/setup-categories.ts` using `npx ts-node` to populate the database with default categories.
+
+Ensure the `DATABASE_URL` environment variable is configured before running the script so the setup can connect to your PostgreSQL database.


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` to install dependencies for root and mobile projects and run the category setup
- document the script in a new `README.md`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `./.codex/setup.sh` *(fails to connect to database)*

------
https://chatgpt.com/codex/tasks/task_e_686787f53fe8832f86be883f29a5738e